### PR TITLE
🐛 Now Ensure Billing Details are Updated when updating existing order

### DIFF
--- a/includes/class-wc-gateway-fastspring-orders.php
+++ b/includes/class-wc-gateway-fastspring-orders.php
@@ -238,8 +238,11 @@ class WC_Gateway_FastSpring_Orders
         )
             return;
 
-        // Update the order with customer data
+        // Ensure the order is associated with the current logged-in user
         $this->ensure_order_customer_is_current_user( $order );
+
+        // Update the order with customer data
+        $this->update_order_with_customer_data( $order, $form_data );
 
         // Update the order with the current cart contents
         $order->remove_order_items();
@@ -793,7 +796,6 @@ class WC_Gateway_FastSpring_Orders
 
         // Update the order with the customer data
         $this->update_order_with_customer_data( $order, $form_data );
-
 
         // Set Order Created Via
         $order->set_created_via( 'checkout' );

--- a/woocommerce-gateway-fastspring.php
+++ b/woocommerce-gateway-fastspring.php
@@ -4,11 +4,11 @@
  * Description: Plugin Taken over by Built Mighty because plugin is no longer maintained: https://github.com/cyberwombat/woocommerce-fastspring-payment-gateway/blob/master/README.md - Accept credit card, PayPal, Amazon Pay and other payments on your store using FastSpring.
  * Author: Enradia
  * Author URI: https://enradia.com/
- * Version: 2.0.0
+ * Version: 2.1.0
  * Requires at least: 4.4
- * Tested up to: 6.6.2
+ * Tested up to: 6.8.1
  * WC requires at least: 3.0
- * WC tested up to: 9.3.1
+ * WC tested up to: 9.9.5
  * Text Domain: woocommerce-gateway-fastspring
  *
  */


### PR DESCRIPTION
This pull request focuses on improving order handling in the FastSpring payment gateway plugin and updating plugin metadata. Key changes include ensuring proper association of orders with logged-in users, refining order creation processes, and updating version and compatibility information.

### Improvements to order handling:

* [`includes/class-wc-gateway-fastspring-orders.php`](diffhunk://#diff-8e89be4f81c9223581c784f711ff212c63eef9cb435c17aa8b284c6ce74987edL241-R246): Added a call to `ensure_order_customer_is_current_user` to ensure orders are associated with the current logged-in user before updating customer data in `update_existing_order`. Additionally, the order creation process (`create_actual_order`) was streamlined by removing unnecessary blank lines. [[1]](diffhunk://#diff-8e89be4f81c9223581c784f711ff212c63eef9cb435c17aa8b284c6ce74987edL241-R246) [[2]](diffhunk://#diff-8e89be4f81c9223581c784f711ff212c63eef9cb435c17aa8b284c6ce74987edL797)

### Plugin metadata updates:

* [`woocommerce-gateway-fastspring.php`](diffhunk://#diff-736360981b18cf021610ff5d5475e45eba6e16baa448e697959553d720b82d99L7-R11): Updated plugin version to `2.1.0`, increased compatibility with WordPress (tested up to `6.8.1`) and WooCommerce (tested up to `9.9.5`).
---

Link to Jira Issue: https://builtmighty.atlassian.net/browse/VAL-753

---

### 📖 Git Flow Reference
```mermaid
flowchart LR
    A[[feature/1234_branch]] --> B{{Merge via PR}}
    B --> C[[rc/x.x.x]]
    C --> D{Run CI/CD?}
    D -->|fa:fa-x Fail Code Checks| E[Commit Fixes] --> D
    D -->|fa:fa-check Pass Code Checks| F[Merge Commit]
    F --> G{ Q/A }
    G --> H{{Merge via PR}}
    H --> I[[main]]
```



