### PR TITLE
✨ Ensure Discounts and Coupons are not added to Temporary Orders but are applied to Actual Order

### DIFF
--- a/includes/class-wc-gateway-fastspring-orders.php
+++ b/includes/class-wc-gateway-fastspring-orders.php
@@ -891,6 +891,9 @@ class WC_Gateway_FastSpring_Orders
         // Apply discounts
         $this->apply_discounts_to_order( $order );
 
+        // Clean up applied discounts session variable
+        WC()->session->set( 'wc_fs_applied_discounts', null );
+
         // Remove the temporary order flag
         $order->delete_meta_data( '_is_temp_order' );
 

--- a/includes/class-wc-gateway-fastspring-orders.php
+++ b/includes/class-wc-gateway-fastspring-orders.php
@@ -352,7 +352,7 @@ class WC_Gateway_FastSpring_Orders
         $order_id = $wc_checkout->create_order( $form_data );
         $order    = wc_get_order( $order_id );
 
-        // Restore coupons and gift cards to cart/session
+        // Restore coupons to cart/session
         foreach ( $applied_discounts['applied_coupons'] as $code ) :
             WC()->cart->apply_coupon( $code );
         endforeach;

--- a/includes/class-wc-gateway-fastspring-orders.php
+++ b/includes/class-wc-gateway-fastspring-orders.php
@@ -343,7 +343,7 @@ class WC_Gateway_FastSpring_Orders
 
         // Remove all coupons
         foreach ( $applied_discounts['applied_coupons'] as $code ) :
-            WC()->cart->remove_coupon($code);
+            WC()->cart->remove_coupon( $code );
         endforeach;
 
         do_action( 'wc_fs_before_create_temp_order', WC()->cart );

--- a/includes/class-wc-gateway-fastspring-orders.php
+++ b/includes/class-wc-gateway-fastspring-orders.php
@@ -78,6 +78,29 @@ class WC_Gateway_FastSpring_Orders
         add_action('woocommerce_cart_emptied', array($this, 'cart_emptied'));
     }
 
+
+    /**
+     * Is Temporary Order
+     * 
+     * @param int|WC_Order $order_or_id - The Order ID or WC_Order object
+     * 
+     * @return bool - True if the order is temporary, false otherwise
+     */
+    public static function is_temp_order( $order_or_id ) {
+        if ( is_numeric( $order_or_id ) ) :
+            $order = wc_get_order( $order_or_id );
+        elseif ( is_a( $order_or_id, 'WC_Order' ) ) :
+            $order = $order_or_id;
+        else :
+            return false;
+        endif;
+
+        if ( ! $order )
+            return false;
+
+        return $order->get_meta( '_is_temp_order' ) === 'yes';
+    }
+
     /**
      * Schedule Delete Old Temporary Orders
      * 
@@ -535,7 +558,7 @@ class WC_Gateway_FastSpring_Orders
         if (
             $order &&
             ! in_array( $order->get_status(), array( 'completed', 'on-hold', 'refunded' ), true ) &&
-            $order->get_meta( '_is_temp_order' ) === 'yes'
+            self::is_temp_order( $order_id )
         ) :
             // Clear the order from the session
             WC()->session->set( 'order_awaiting_payment', null );

--- a/includes/class-wc-gateway-fastspring-orders.php
+++ b/includes/class-wc-gateway-fastspring-orders.php
@@ -334,7 +334,7 @@ class WC_Gateway_FastSpring_Orders
      * @return int|bool - The Order ID if successful, false otherwise
      */
     public function create_temp_order( $form_data, $wc_checkout ) {
-        // Backup applied coupons and gift cards
+        // Backup applied coupons
         $applied_discounts = [
             'applied_coupons' => WC()->cart->get_applied_coupons(),
         ];

--- a/includes/class-wc-gateway-fastspring-orders.php
+++ b/includes/class-wc-gateway-fastspring-orders.php
@@ -354,7 +354,7 @@ class WC_Gateway_FastSpring_Orders
 
         // Restore coupons and gift cards to cart/session
         foreach ( $applied_discounts['applied_coupons'] as $code ) :
-            WC()->cart->apply_coupon($code);
+            WC()->cart->apply_coupon( $code );
         endforeach;
 
         do_action( 'wc_fs_after_create_temp_order', WC()->cart );

--- a/readme.txt
+++ b/readme.txt
@@ -125,3 +125,13 @@ N/A
 = 2.3.0 =
 * Improved checkout process reliability by adding an `isCheckoutProcessing` flag to prevent double submissions and duplicate orders.
 * Enhanced event handling for the `#place_order` button to support both click and keyboard events, restricting form submission to valid user actions (only on Enter key for keyboard events).
+
+= 2.4.0 =
+
+* Enhanced temporary order handling by persisting applied coupons and discount data in order meta for improved reliability.
+* Added static is_temp_order method for consistent and reusable temporary order identification.
+* Refactored codebase to use is_temp_order for all temporary order checks.
+* During temporary order creation, applied coupons are now backed up, removed from the cart, and restored after order creation to maintain cart consistency.
+* Applied coupons and discount totals are now stored in the _fs_temp_order_data meta key, with new wc_fs_temp_order_data filter and wc_fs_update_temp_order_meta action for extensibility.
+* Discounts are now applied to finalized orders using data from temporary order meta, not the current cart, ensuring accuracy.
+* Temporary order meta (_fs_temp_order_data) is now deleted when converting to an actual order, preventing stale or orphaned data.

--- a/readme.txt
+++ b/readme.txt
@@ -129,7 +129,7 @@ N/A
 = 2.4.0 =
 
 * Enhanced temporary order handling by persisting applied coupons and discount data in order meta for improved reliability.
-* Added static is_temp_order method for consistent and reusable temporary order identification.
+* Added static `is_temp_order` method for consistent and reusable temporary order identification.
 * Refactored codebase to use `is_temp_order` for all temporary order checks.
 * During temporary order creation, applied coupons are now backed up, removed from the cart, and restored after order creation to maintain cart consistency.
 * Applied coupons and discount totals are now stored in the `_fs_temp_order_data` meta key, with new `wc_fs_temp_order_data` filter and `wc_fs_update_temp_order_meta` action for extensibility.

--- a/readme.txt
+++ b/readme.txt
@@ -130,7 +130,7 @@ N/A
 
 * Enhanced temporary order handling by persisting applied coupons and discount data in order meta for improved reliability.
 * Added static is_temp_order method for consistent and reusable temporary order identification.
-* Refactored codebase to use is_temp_order for all temporary order checks.
+* Refactored codebase to use `is_temp_order` for all temporary order checks.
 * During temporary order creation, applied coupons are now backed up, removed from the cart, and restored after order creation to maintain cart consistency.
 * Applied coupons and discount totals are now stored in the _fs_temp_order_data meta key, with new wc_fs_temp_order_data filter and wc_fs_update_temp_order_meta action for extensibility.
 * Discounts are now applied to finalized orders using data from temporary order meta, not the current cart, ensuring accuracy.

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,6 @@ N/A
 * Added static is_temp_order method for consistent and reusable temporary order identification.
 * Refactored codebase to use `is_temp_order` for all temporary order checks.
 * During temporary order creation, applied coupons are now backed up, removed from the cart, and restored after order creation to maintain cart consistency.
-* Applied coupons and discount totals are now stored in the _fs_temp_order_data meta key, with new wc_fs_temp_order_data filter and wc_fs_update_temp_order_meta action for extensibility.
+* Applied coupons and discount totals are now stored in the `_fs_temp_order_data` meta key, with new `wc_fs_temp_order_data` filter and `wc_fs_update_temp_order_meta` action for extensibility.
 * Discounts are now applied to finalized orders using data from temporary order meta, not the current cart, ensuring accuracy.
 * Temporary order meta (_fs_temp_order_data) is now deleted when converting to an actual order, preventing stale or orphaned data.


### PR DESCRIPTION
> [!TIP]
> <img width="64" height="40" alt="image" src="https://github.com/user-attachments/assets/2c888c95-6811-402f-97d0-fbf1e367b38c" style="max-height:150px" /><br>
> **Copilot Code Review**
> Copilot will automatically review your code if you're merging a branch into the `rc/`. Please let it finish before merging. You can view more documentation [📓 here 📓](https://builtmighty.atlassian.net/wiki/spaces/BMH/pages/755793924/Copilot+Code+Review).

---

## 🔎 Overview 
This pull request enhances the handling of temporary WooCommerce orders by improving how discounts and coupons are managed and tracked throughout the order lifecycle. The main improvements include persisting applied coupons and discount data in order meta, providing utility methods for identifying temporary orders, and ensuring discounts are correctly restored and applied. These changes improve reliability and extensibility for temporary order workflows.

**Temporary Order Identification & Management:**
- Added a static method `is_temp_order` to reliably check if an order is marked as temporary, improving code clarity and reusability.
- Refactored code to use `is_temp_order` for checking temporary order status, ensuring consistent logic across the codebase.

**Discounts and Coupons Handling:**
- During temporary order creation, now backs up applied coupons, removes them from the cart, and restores them after order creation, ensuring the cart state remains consistent for the user.
- Stores applied coupons and discount totals in the temporary order's meta data (`_fs_temp_order_data`), with a filter (`wc_fs_temp_order_data`) and action (`wc_fs_update_temp_order_meta`) for extensibility.
- When applying discounts to an order, retrieves coupons from the stored temporary order meta instead of the current cart, ensuring accuracy during order finalization.

**Order Cleanup:**
- Ensures that temporary order meta data (`_fs_temp_order_data`) is deleted when converting a temporary order to an actual order, preventing stale data.

---

### 📖 Git Flow Reference
```mermaid
flowchart LR
    A[[feature/1234_branch]] --> B{{Merge via PR}}
    B --> C[[rc/x.x.x]]
    C --> D{Run CI/CD?}
    D -->|fa:fa-x Fail Code Checks| E[Commit Fixes] --> D
    D -->|fa:fa-check Pass Code Checks| F[Merge Commit]
    F --> G{ Q/A }
    G --> H{{Merge via PR}}
    H --> I[[main]]
```



