### PR TITLE
🚀 Release 2.5.1

### DIFF
--- a/includes/class-wc-gateway-fastspring-handler.php
+++ b/includes/class-wc-gateway-fastspring-handler.php
@@ -135,32 +135,43 @@ class WC_Gateway_FastSpring_Handler
         $order_status = $order ? $order->get_status() : '';
 
         // Popup closed with payment
-        if ($order && $payload->reference) {
-
-            // Get API order status if available
-            $status = $this->get_order_status($payload->id);
-
-            // Remove cart
-            WC()->cart->empty_cart();
-
-            $order->set_transaction_id($payload->reference);
-            $order->update_meta_data('fs_order_id', $payload->id);
-
-            if ($status === 'completed' && $order->payment_complete($payload->reference)) {
-                $this->log(sprintf('Marking order ID %s as completed', $order->get_id()));
-                $order->add_order_note(sprintf(__('<b>FastSpring payment approved.</b><br/> <b>ID:</b> %1$s', 'woocommerce'), $order->get_id()));
-            }
-            // We could have a race condition where FS already called webhook so lets not assume its pending
-            elseif ($order_status != 'completed') {
-                $order->update_status('pending', __('Order pending payment approval.', 'woocommerce'));
-            }
-
-            $data = ["redirect_url" => WC_Gateway_FastSpring_Handler::get_return_url($order), 'order_id' => $order_id];
-
-            wp_send_json($data);
-        } else {
-            wp_send_json_error('Order not found - Order ID was' . $order_id);
+        // If order or payload reference is missing, bail out early
+        if ( !$order ) {
+            wp_send_json_error( 'Order not found - Order ID was' . $order_id );
+            return;
         }
+            
+        if ( !isset($payload->reference) ) {
+            wp_send_json_error( 'Reference not found' );
+            return;
+        }
+
+        if ( empty( $payload->reference ) ) {
+            wp_send_json_error( 'Reference is empty' );
+            return;
+        }
+
+        // Get API order status if available
+        $status = $this->get_order_status($payload->id);
+
+        // Remove cart
+        WC()->cart->empty_cart();
+
+        $order->set_transaction_id($payload->reference);
+        $order->update_meta_data('fs_order_id', $payload->id);
+
+        if ($status === 'completed' && $order->payment_complete($payload->reference)) {
+            $this->log(sprintf('Marking order ID %s as completed', $order->get_id()));
+            $order->add_order_note(sprintf(__('<b>FastSpring payment approved.</b><br/> <b>ID:</b> %1$s', 'woocommerce'), $order->get_id()));
+        }
+        // We could have a race condition where FS already called webhook so lets not assume its pending
+        elseif ($order_status != 'completed') {
+            $order->update_status('pending', __('Order pending payment approval.', 'woocommerce'));
+        }
+
+        $data = ["redirect_url" => WC_Gateway_FastSpring_Handler::get_return_url($order), 'order_id' => $order_id];
+
+        wp_send_json($data);
     }
 
     /**

--- a/includes/class-wc-gateway-fastspring-handler.php
+++ b/includes/class-wc-gateway-fastspring-handler.php
@@ -98,7 +98,7 @@ class WC_Gateway_FastSpring_Handler
     {
         $payload = json_decode(file_get_contents('php://input'));
 
-        $security = ( is_object($payload ) && isset( $payload->security ) ) ?
+        $security = ( is_object($payload) && isset( $payload->security ) ) ?
             $payload->security :
             '';
         $allowed = wp_verify_nonce( $security, 'wc-fastspring-receipt' );

--- a/includes/class-wc-gateway-fastspring-handler.php
+++ b/includes/class-wc-gateway-fastspring-handler.php
@@ -98,7 +98,10 @@ class WC_Gateway_FastSpring_Handler
     {
         $payload = json_decode(file_get_contents('php://input'));
 
-        $allowed = wp_verify_nonce($payload->security, 'wc-fastspring-receipt');
+        $security = ( is_object($payload ) && isset( $payload->security ) ) ?
+            $payload->security :
+            '';
+        $allowed = wp_verify_nonce( $security, 'wc-fastspring-receipt' );
 
         // PATCH:
 		// Date: 5-10-2024
@@ -121,7 +124,11 @@ class WC_Gateway_FastSpring_Handler
         // Ensure session is set for current_order
         WC()->session->set('current_order', $order_id);
 
-        $data = ['order_id' => $order->get_id()];
+        if ($order) {
+            $data = ['order_id' => $order->get_id()];
+        } else {
+            $data = ['order_id' => 0];
+        }
 
         // Check for double calls
         $order_status = $order->get_status();

--- a/includes/class-wc-gateway-fastspring-handler.php
+++ b/includes/class-wc-gateway-fastspring-handler.php
@@ -127,11 +127,12 @@ class WC_Gateway_FastSpring_Handler
         if ($order) {
             $data = ['order_id' => $order->get_id()];
         } else {
+            // Fallback when order does not exist or cannot be loaded.
             $data = ['order_id' => 0];
         }
 
-        // Check for double calls
-        $order_status = $order->get_status();
+        // Check for double calls, but avoid calling methods on a non-existent order.
+        $order_status = $order ? $order->get_status() : '';
 
         // Popup closed with payment
         if ($order && $payload->reference) {

--- a/includes/class-wc-gateway-fastspring-orders.php
+++ b/includes/class-wc-gateway-fastspring-orders.php
@@ -620,7 +620,12 @@ class WC_Gateway_FastSpring_Orders
             self::is_temp_order( $order_id )
         ) :
             // Clear the order from the session
-            WC()->session->set( 'order_awaiting_payment', null );
+            if (
+                isset( WC()->session ) &&
+                method_exists( WC()->session, 'set' )
+            ) :
+                WC()->session->set( 'order_awaiting_payment', null );
+            endif;
 
             // Delete the order
             $order->delete( true );

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 ﻿=== FastSpring for WooCommerce ===
 Contributors: Enradia, Built Mighty
 Tags: WooCommerce, Payment Gateway
-Version: 2.5.0
+Version: 2.5.1
 Requires PHP: 7.4
 Requires at least: 4.4
 Tested up to: 6.8.1

--- a/readme.txt
+++ b/readme.txt
@@ -141,3 +141,8 @@ N/A
 * Improved the redirect logic in `fastspringPopupCloseHandler` (`assets/js/fastspring-checkout.js`) to check for the existence of `redirect_url` before attempting a redirect, and to construct the URL more robustly using the `URL` API. Throws an error if the redirect URL is missing.
 * Wrapped the reload script in an IIFE and fixed the selector logic in `reload_checkout_on_order_received_script` (`includes/class-wc-gateway-fastspring.php`) to only execute when appropriate.
 * Ensured the reload script is properly closed and executed by moving the closing parenthesis and semicolon into the script block.
+
+= 2.5.1 =
+* Improved nonce verification in `ajax_get_receipt()` by checking for the security field before verifying, preventing errors from malformed payloads.
+* Enhanced order data handling in `ajax_get_receipt()` by setting `order_id` to `0` if the order object is not found, avoiding undefined variable issues.
+* Added checks before clearing the session in `delete_temp_order()` to ensure the session object exists and supports the required method, preventing runtime errors.

--- a/woocommerce-gateway-fastspring.php
+++ b/woocommerce-gateway-fastspring.php
@@ -4,11 +4,11 @@
  * Description: Plugin Taken over by Built Mighty because plugin is no longer maintained: https://github.com/cyberwombat/woocommerce-fastspring-payment-gateway/blob/master/README.md - Accept credit card, PayPal, Amazon Pay and other payments on your store using FastSpring.
  * Author: Enradia
  * Author URI: https://enradia.com/
- * Version: 2.5.0
+ * Version: 2.5.1
  * Requires at least: 4.4
- * Tested up to: 6.8.1
+ * Tested up to: 6.9
  * WC requires at least: 3.0
- * WC tested up to: 9.9.5
+ * WC tested up to: 10.4.3
  * Text Domain: woocommerce-gateway-fastspring
  *
  */


### PR DESCRIPTION
> [!TIP]
> <img width="64" height="40" alt="image" src="https://github.com/user-attachments/assets/2c888c95-6811-402f-97d0-fbf1e367b38c" style="max-height:150px" /><br>
> **Copilot Code Review**
> Copilot will automatically review your code if you're merging a branch into the `rc/`. Please let it finish before merging. You can view more documentation [📓 here 📓](https://builtmighty.atlassian.net/wiki/spaces/BMH/pages/755793924/Copilot+Code+Review).

## 🔎 Overview 
This pull request focuses on improving the robustness of the FastSpring WooCommerce gateway by adding better error handling and validation in the order receipt and session management processes. It also updates the plugin version and compatibility information.

**Error handling and validation improvements:**

* Improved nonce verification in `ajax_get_receipt()` by checking for the existence of the `security` field in the payload before verifying, preventing errors from malformed or missing data.
* Enhanced order data handling in `ajax_get_receipt()` by setting `order_id` to `0` if the order object is not found, and adding early returns with error messages when the order or required reference is missing, avoiding undefined variable issues and improving error feedback. [[1]](diffhunk://#diff-f4e859192ae3b1d4828af18dfb32be23e0b68d9b565ed2f9a03499310fb61f1dR127-R152) [[2]](diffhunk://#diff-f4e859192ae3b1d4828af18dfb32be23e0b68d9b565ed2f9a03499310fb61f1dL153-L155)

**Session and order management:**

* Added checks before clearing the session in `delete_temp_order()` to ensure the session object exists and supports the required method, preventing runtime errors in certain edge cases.

**Version and documentation updates:**

* Bumped plugin version to `2.5.1` and updated compatibility information in `readme.txt` and `woocommerce-gateway-fastspring.php`. [[1]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L4-R4) [[2]](diffhunk://#diff-736360981b18cf021610ff5d5475e45eba6e16baa448e697959553d720b82d99L7-R11)
* Documented the new changes in the changelog section of `readme.txt`.

---

### 📖 Git Flow Reference
```mermaid
flowchart LR
    A[[feature/1234_branch]] --> B{{Merge via PR}}
    B --> C[[rc/x.x.x]]
    C --> D{Run CI/CD?}
    D -->|fa:fa-x Fail Code Checks| E[Commit Fixes] --> D
    D -->|fa:fa-check Pass Code Checks| F[Merge Commit]
    F --> G{ Q/A }
    G --> H{{Merge via PR}}
    H --> I[[main]]
```



