### PR TITLE
🔖 Release 2.6.0

### DIFF
--- a/includes/class-wc-gateway-fastspring-handler.php
+++ b/includes/class-wc-gateway-fastspring-handler.php
@@ -211,6 +211,10 @@ class WC_Gateway_FastSpring_Handler
 
         add_action('woocommerce_api_wc_gateway_fastspring', array($this, 'listen_webhook_request'));
         add_action('woocommerce_fastspring_handle_webhook_request', array($this, 'handle_webhook_request'));
+
+        // VAL-879: surface missing-order webhooks to admins.
+        add_action('admin_notices', array($this, 'maybe_show_orphan_admin_notice'));
+        add_action('admin_post_wc_fs_dismiss_orphan_notices', array($this, 'dismiss_orphan_notices'));
     }
 
     /**
@@ -245,6 +249,9 @@ class WC_Gateway_FastSpring_Handler
 
         if (!isset($id)) {
             $this->log('No order ID found in webhook');
+            // VAL-879: capture for review — payload is unusable without store_order_id
+            // but we still want an admin alert so the failure isn't silent.
+            $this->quarantine_orphan_webhook($payload, 'unknown');
             throw new Exception('No order ID found in webhook');
         }
 
@@ -252,9 +259,175 @@ class WC_Gateway_FastSpring_Handler
 
         if (!$order) {
             $this->log(sprintf('No order found with transaction ID %s', $id));
+            // VAL-879: order vanished between checkout and payment (cleanup cron race).
+            // Quarantine the payload, alert the team, then continue raising so FS retries.
+            $this->quarantine_orphan_webhook($payload, $id);
             throw new Exception(sprintf('Unable to locate order with FS transaction ID %s', $id));
         }
         return $order;
+    }
+
+    /**
+     * Record an FS webhook whose Woo order is missing and alert the team (VAL-879).
+     *
+     * Persists a summary entry in the `wc_fs_orphan_webhooks` option for the admin
+     * notice to read, and emails the site admin once per FS reference per day.
+     * The full payload is also written to the FastSpring log for forensic replay.
+     *
+     * @param object $payload            The FS webhook event payload
+     * @param string $expected_order_id  The Woo order ID we tried to load (or 'unknown')
+     * @return void
+     */
+    private function quarantine_orphan_webhook( $payload, $expected_order_id )
+    {
+        $fs_reference   = isset($payload->reference) ? (string) $payload->reference : null;
+        $event_type     = isset($payload->type) ? (string) $payload->type : 'unknown';
+        $customer_email = isset($payload->data->customer->email) ? (string) $payload->data->customer->email : null;
+        $amount         = isset($payload->data->totalValue) ? $payload->data->totalValue : (
+            isset($payload->data->total) ? $payload->data->total : null
+        );
+        $currency       = isset($payload->data->currency) ? (string) $payload->data->currency : null;
+
+        // Forensic dump — full payload to the FS log so we can replay manually.
+        $this->log( sprintf(
+            'VAL-879 ORPHAN WEBHOOK — event=%s expected_order_id=%s fs_reference=%s payload=%s',
+            $event_type,
+            $expected_order_id,
+            $fs_reference ?: 'unknown',
+            wp_json_encode( $payload )
+        ) );
+
+        // Persist a lightweight summary for the admin notice.
+        $orphans = get_option( 'wc_fs_orphan_webhooks', array() );
+        if ( ! is_array( $orphans ) ) {
+            $orphans = array();
+        }
+        $orphans[] = array(
+            'received_at'       => current_time( 'mysql', true ),
+            'event_type'        => $event_type,
+            'expected_order_id' => $expected_order_id,
+            'fs_reference'      => $fs_reference,
+            'customer_email'    => $customer_email,
+            'amount'            => $amount,
+            'currency'          => $currency,
+        );
+        // Cap at 100 entries so the option can't grow without bound.
+        if ( count( $orphans ) > 100 ) {
+            $orphans = array_slice( $orphans, -100 );
+        }
+        update_option( 'wc_fs_orphan_webhooks', $orphans, false );
+
+        // Dedupe email alerts per FS reference per 24h so retry storms don't spam.
+        $dedupe_key = 'wc_fs_orphan_alert_' . md5( $fs_reference ?: $expected_order_id );
+        if ( get_transient( $dedupe_key ) ) {
+            $this->log( sprintf( 'VAL-879 orphan alert suppressed (already sent within 24h) for FS reference %s', $fs_reference ?: 'unknown' ) );
+            return;
+        }
+        set_transient( $dedupe_key, 1, DAY_IN_SECONDS );
+
+        $this->send_orphan_webhook_email( $event_type, $expected_order_id, $fs_reference, $customer_email, $amount, $currency );
+    }
+
+    /**
+     * Email the site admin about a missing-order webhook (VAL-879).
+     *
+     * @return void
+     */
+    private function send_orphan_webhook_email( $event_type, $expected_order_id, $fs_reference, $customer_email, $amount, $currency )
+    {
+        $admin_email = get_option( 'admin_email' );
+        if ( empty( $admin_email ) ) {
+            $this->log( 'VAL-879 cannot send orphan alert — admin_email is empty' );
+            return;
+        }
+
+        $site_name = wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES );
+
+        $subject = sprintf(
+            '[%s] FastSpring webhook for missing Woo order #%s',
+            $site_name,
+            $expected_order_id
+        );
+
+        $logs_url = admin_url( 'admin.php?page=wc-status&tab=logs' );
+
+        $body  = "A FastSpring webhook arrived referencing a Woo order that no longer exists.\n";
+        $body .= "The customer's payment was processed by FastSpring but no license was issued.\n";
+        $body .= "Manual recovery is required.\n\n";
+        $body .= "Event type:           {$event_type}\n";
+        $body .= "FS reference:         " . ( $fs_reference ?: 'unknown' ) . "\n";
+        $body .= "Expected Woo order:   #{$expected_order_id}\n";
+        $body .= "Customer email:       " . ( $customer_email ?: 'unknown' ) . "\n";
+        $body .= "Amount:               " . ( $amount !== null ? $amount : 'unknown' ) . ' ' . ( $currency ?: '' ) . "\n\n";
+        $body .= "Full payload has been logged to the FastSpring log on the server.\n";
+        $body .= "Review at: {$logs_url}\n";
+
+        $sent = wp_mail( $admin_email, $subject, $body );
+        $this->log( sprintf(
+            'VAL-879 orphan alert email %s for FS reference %s (to %s)',
+            $sent ? 'sent' : 'FAILED',
+            $fs_reference ?: 'unknown',
+            $admin_email
+        ) );
+    }
+
+    /**
+     * Show an admin notice when orphan webhooks have been quarantined (VAL-879).
+     *
+     * @return void
+     *
+     * @hook admin_notices
+     */
+    public function maybe_show_orphan_admin_notice()
+    {
+        if ( ! current_user_can( 'manage_woocommerce' ) ) {
+            return;
+        }
+
+        $orphans = get_option( 'wc_fs_orphan_webhooks', array() );
+        if ( empty( $orphans ) || ! is_array( $orphans ) ) {
+            return;
+        }
+
+        $count        = count( $orphans );
+        $latest       = end( $orphans );
+        $latest_ref   = isset( $latest['fs_reference'] ) ? $latest['fs_reference'] : 'unknown';
+        $latest_email = isset( $latest['customer_email'] ) ? $latest['customer_email'] : 'unknown';
+        $dismiss_url  = wp_nonce_url(
+            admin_url( 'admin-post.php?action=wc_fs_dismiss_orphan_notices' ),
+            'wc_fs_dismiss_orphan_notices'
+        );
+        $logs_url     = admin_url( 'admin.php?page=wc-status&tab=logs' );
+
+        printf(
+            '<div class="notice notice-error"><p><strong>FastSpring:</strong> %d orphan webhook(s) — payment received but no matching Woo order. Latest: FS reference <code>%s</code> for <code>%s</code>. Check the <a href="%s">FastSpring log</a> for the full payload and replay manually. <a href="%s">Dismiss</a></p></div>',
+            (int) $count,
+            esc_html( $latest_ref ),
+            esc_html( $latest_email ),
+            esc_url( $logs_url ),
+            esc_url( $dismiss_url )
+        );
+    }
+
+    /**
+     * Dismiss the orphan-webhook admin notice (VAL-879).
+     *
+     * @return void
+     *
+     * @hook admin_post_wc_fs_dismiss_orphan_notices
+     */
+    public function dismiss_orphan_notices()
+    {
+        if ( ! current_user_can( 'manage_woocommerce' ) ) {
+            wp_die( 'Forbidden', 'Forbidden', array( 'response' => 403 ) );
+        }
+        check_admin_referer( 'wc_fs_dismiss_orphan_notices' );
+
+        delete_option( 'wc_fs_orphan_webhooks' );
+
+        $redirect = wp_get_referer() ?: admin_url();
+        wp_safe_redirect( $redirect );
+        exit;
     }
 
     /**

--- a/includes/class-wc-gateway-fastspring-orders.php
+++ b/includes/class-wc-gateway-fastspring-orders.php
@@ -366,6 +366,10 @@ class WC_Gateway_FastSpring_Orders
         // NOTE: We are not storing this in the Temp Order Data Array to ensure it is easily queryable with a meta query.
         $order->update_meta_data( '_is_temp_order', 'yes' );
 
+        // Timestamp the FS checkout start so the cleanup cron can exempt orders
+        // whose FastSpring session may still be in flight (VAL-879).
+        $order->update_meta_data( '_fs_checkout_started_at', time() );
+
         // Add an order note.
         $order->add_order_note( 'Temporary order created.' );
 
@@ -686,17 +690,37 @@ class WC_Gateway_FastSpring_Orders
     }
 
     /**
+     * Get the exemption window for in-flight FastSpring checkout sessions (VAL-879).
+     *
+     * Temp orders whose `_fs_checkout_started_at` timestamp falls within this
+     * window are skipped by the cleanup cron, so an active FastSpring popup
+     * session can never have its underlying Woo order deleted out from under it.
+     *
+     * Defaults to 7 days. Filter `wc_fs_session_exemption_window` to override.
+     *
+     * @return int Exemption window in seconds.
+     */
+    public static function get_fs_session_exemption_window() {
+        return (int) apply_filters( 'wc_fs_session_exemption_window', 7 * DAY_IN_SECONDS );
+    }
+
+    /**
      * Delete Old Temporary Orders
-     * 
+     *
      * @return void
-     * 
+     *
      * @hook wc_fs_delete_old_temp_orders
      */
     public function delete_old_temp_orders() {
-        // Delete orders older than 24 hours
+        // Delete orders older than the configured timeout (default 24h)
         $time_out = WC_Gateway_FastSpring::get_temp_order_timeout();
 
         $time     = ( time() - $time_out );
+
+        // VAL-879: orders whose FS checkout started within the exemption window
+        // are still considered potentially in-flight and must not be deleted.
+        $exemption_window    = self::get_fs_session_exemption_window();
+        $exemption_threshold = time() - $exemption_window;
 
         // Query for pending temporary orders
         $args = array(
@@ -709,6 +733,12 @@ class WC_Gateway_FastSpring_Orders
         $orders = wc_get_orders( $args );
 
         foreach ( $orders as $order ) :
+            // Skip orders with an FS checkout session inside the exemption window (VAL-879).
+            $fs_started_at = (int) $order->get_meta( '_fs_checkout_started_at' );
+            if ( $fs_started_at > 0 && $fs_started_at > $exemption_threshold ) :
+                continue;
+            endif;
+
             $this->delete_temp_order( $order->get_id() );
         endforeach;
     }

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 ﻿=== FastSpring for WooCommerce ===
 Contributors: Enradia, Built Mighty
 Tags: WooCommerce, Payment Gateway
-Version: 2.5.1
+Version: 2.6.0
 Requires PHP: 7.4
 Requires at least: 4.4
 Tested up to: 6.8.1

--- a/readme.txt
+++ b/readme.txt
@@ -146,3 +146,9 @@ N/A
 * Improved nonce verification in `ajax_get_receipt()` by checking for the security field before verifying, preventing errors from malformed payloads.
 * Enhanced order data handling in `ajax_get_receipt()` by setting `order_id` to `0` if the order object is not found, avoiding undefined variable issues.
 * Added checks before clearing the session in `delete_temp_order()` to ensure the session object exists and supports the required method, preventing runtime errors.
+
+= 2.6.0 =
+* Stamp temp orders with `_fs_checkout_started_at` at checkout creation so the cleanup cron can detect in-flight FastSpring sessions (VAL-879).
+* Exempt temp orders from `delete_old_temp_orders()` when their FS checkout started within a 7-day window — filterable via `wc_fs_session_exemption_window` — preventing the cron from deleting orders out from under an open FastSpring popup (VAL-879).
+* Quarantine FastSpring webhooks whose referenced Woo order no longer exists: persist a summary entry in the `wc_fs_orphan_webhooks` option, dump the full payload to the FastSpring log, and email the site admin (deduped per FS reference per 24h) so silent webhook failures surface immediately (VAL-879).
+* Add a dismissible admin notice on `manage_woocommerce` screens that summarizes quarantined orphan webhooks and links to the FastSpring log for manual replay (VAL-879).

--- a/woocommerce-gateway-fastspring.php
+++ b/woocommerce-gateway-fastspring.php
@@ -4,7 +4,7 @@
  * Description: Plugin Taken over by Built Mighty because plugin is no longer maintained: https://github.com/cyberwombat/woocommerce-fastspring-payment-gateway/blob/master/README.md - Accept credit card, PayPal, Amazon Pay and other payments on your store using FastSpring.
  * Author: Enradia
  * Author URI: https://enradia.com/
- * Version: 2.5.1
+ * Version: 2.6.0
  * Requires at least: 4.4
  * Tested up to: 6.9
  * WC requires at least: 3.0
@@ -21,7 +21,7 @@ if (!defined('ABSPATH')) {
 /**
  * Required minimums and constants
  */
-define('WC_FASTSPRING_VERSION', '2.0.0');
+define('WC_FASTSPRING_VERSION', '2.6.0');
 define('WC_FASTSPRING_SCRIPT', 'https://d1f8f9xcsvx3ha.cloudfront.net/sbl/0.8.3/fastspring-builder.min.js');
 define('WC_FASTSPRING_MIN_PHP_VER', '5.6.0');
 define('WC_FASTSPRING_MIN_WC_VER', '3.0.0');


### PR DESCRIPTION
Merges `rc/2.6.0` into `master` for the 2.6.0 release.

Includes:
- **VAL-816** — Bump version 2.5.1 → 2.6.0 in readme and main plugin file
- **VAL-879** — Quarantine orphan FastSpring webhooks and exempt in-flight checkout sessions from temp-order cleanup