### PR TITLE
(VAL-882) 🐛 Resolve FastSpring checkout module load failure

### DIFF
--- a/includes/class-wc-gateway-fastspring-orders.php
+++ b/includes/class-wc-gateway-fastspring-orders.php
@@ -935,6 +935,12 @@ class WC_Gateway_FastSpring_Orders
         // Remove temporary order data
         $order->delete_meta_data( '_fs_temp_order_data' );
 
+        // VAL-882: Clean up the FS checkout timestamp that VAL-879 writes in
+        // create_temp_order(). Once the temp order has been converted to an
+        // actual order the cron exemption no longer applies — leaving the meta
+        // behind clutters completed orders with stale data.
+        $order->delete_meta_data( '_fs_checkout_started_at' );
+
         // Calculate totals
         $order->calculate_totals();
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 ﻿=== FastSpring for WooCommerce ===
 Contributors: Enradia, Built Mighty
 Tags: WooCommerce, Payment Gateway
-Version: 2.6.0
+Version: 2.6.1
 Requires PHP: 7.4
 Requires at least: 4.4
 Tested up to: 6.8.1

--- a/woocommerce-gateway-fastspring.php
+++ b/woocommerce-gateway-fastspring.php
@@ -4,7 +4,7 @@
  * Description: Plugin Taken over by Built Mighty because plugin is no longer maintained: https://github.com/cyberwombat/woocommerce-fastspring-payment-gateway/blob/master/README.md - Accept credit card, PayPal, Amazon Pay and other payments on your store using FastSpring.
  * Author: Enradia
  * Author URI: https://enradia.com/
- * Version: 2.6.0
+ * Version: 2.6.1
  * Requires at least: 4.4
  * Tested up to: 6.9
  * WC requires at least: 3.0
@@ -21,7 +21,7 @@ if (!defined('ABSPATH')) {
 /**
  * Required minimums and constants
  */
-define('WC_FASTSPRING_VERSION', '2.6.0');
+define('WC_FASTSPRING_VERSION', '2.6.1');
 define('WC_FASTSPRING_SCRIPT', 'https://d1f8f9xcsvx3ha.cloudfront.net/sbl/0.8.3/fastspring-builder.min.js');
 define('WC_FASTSPRING_MIN_PHP_VER', '5.6.0');
 define('WC_FASTSPRING_MIN_WC_VER', '3.0.0');

--- a/woocommerce-gateway-fastspring.php
+++ b/woocommerce-gateway-fastspring.php
@@ -144,6 +144,11 @@ if (!class_exists('WC_FastSpring')):
       {
           if ('fastspring' === $handle) {
               $debug = defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ? 'true' : 'false';
+              // VAL-882: WP 6.3+ auto-injects id="fastspring-js" during enqueue. Strip
+              // it so our id="fsc-api" injection below isn't a duplicate — the FS
+              // Builder library locates its own script tag via getElementById('fsc-api')
+              // and throws on null when the browser parses only the first (WP-added) id.
+              $tag = preg_replace( '/\s+id="[^"]*"/', '', $tag, 1 );
               return str_replace(' src', ' id="fsc-api" data-storefront="' . $this->get_storefront_path() . '" data-before-requests-callback="fastspringBeforeRequestHandler" data-access-key="' . self::get_setting('access_key') . '" '. ($debug ? 'data-debug="true" data-test="' . (self::get_setting('testmode') ? 'yes' : 'no') . '" data-version="' . WC_FASTSPRING_VERSION .'" data-data-callback="dataCallbackFunction" data-error-callback="errorCallback"' : '') . ' data-popup-closed="fastspringPopupCloseHandler" src', $tag);
           }
           return $tag;


### PR DESCRIPTION
## What Type of Change is This?
- [x] 🐛 Bug fix

---

## 🔎 Overview
### What is the current issue or behavior?
* [VAL-882](https://builtmighty.atlassian.net/browse/VAL-882)
* The FastSpring checkout module fails to load at checkout. WordPress 6.3+ auto-injects `id="fastspring-js"` on every enqueued script tag, and our `script_loader_tag` filter then injected a second `id="fsc-api"` on the same tag. Browsers keep only the first `id`, so the FastSpring Builder library's `document.getElementById('fsc-api')` lookup returns `null` and the module throws on init — the popup never opens.
* Secondary issue from VAL-879: the `_fs_checkout_started_at` meta written on temp-order creation was never cleared once the temp order converted to a real one, leaving the cron-exemption marker on finalized orders.

### What is the solution or new behavior?
* Strip the WP-auto-injected `id` attribute from the FS script tag before adding our own, so only `id="fsc-api"` remains and the FS Builder library can find its anchor.
* Delete `_fs_checkout_started_at` in the temp-order conversion path alongside the existing `_fs_temp_order_data` cleanup, so completed orders don't carry stale checkout-session timestamps.
* Bump plugin version 2.6.0 → 2.6.1.

---

## 👷 Deployment Notes/Testing Steps
- [ ] Open a product, proceed to checkout, select FastSpring, and confirm the popup opens (no module-init error in the browser console).
- [ ] View the FS script tag in the page source — confirm it has `id="fsc-api"` and **no** `id="fastspring-js"`.
- [ ] Complete a successful FS checkout end-to-end and verify the converted Woo order has neither `_fs_checkout_started_at` nor `_fs_temp_order_data` in its meta.
- [ ] Verify the temp-order cleanup cron still skips in-flight checkout sessions (regression check for VAL-879).
