### PR TITLE
🔖 Release 2.6.1

### DIFF
--- a/includes/class-wc-gateway-fastspring-orders.php
+++ b/includes/class-wc-gateway-fastspring-orders.php
@@ -935,6 +935,12 @@ class WC_Gateway_FastSpring_Orders
         // Remove temporary order data
         $order->delete_meta_data( '_fs_temp_order_data' );
 
+        // VAL-882: Clean up the FS checkout timestamp that VAL-879 writes in
+        // create_temp_order(). Once the temp order has been converted to an
+        // actual order the cron exemption no longer applies — leaving the meta
+        // behind clutters completed orders with stale data.
+        $order->delete_meta_data( '_fs_checkout_started_at' );
+
         // Calculate totals
         $order->calculate_totals();
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 ﻿=== FastSpring for WooCommerce ===
 Contributors: Enradia, Built Mighty
 Tags: WooCommerce, Payment Gateway
-Version: 2.6.0
+Version: 2.6.1
 Requires PHP: 7.4
 Requires at least: 4.4
 Tested up to: 6.8.1

--- a/readme.txt
+++ b/readme.txt
@@ -152,3 +152,7 @@ N/A
 * Exempt temp orders from `delete_old_temp_orders()` when their FS checkout started within a 7-day window — filterable via `wc_fs_session_exemption_window` — preventing the cron from deleting orders out from under an open FastSpring popup (VAL-879).
 * Quarantine FastSpring webhooks whose referenced Woo order no longer exists: persist a summary entry in the `wc_fs_orphan_webhooks` option, dump the full payload to the FastSpring log, and email the site admin (deduped per FS reference per 24h) so silent webhook failures surface immediately (VAL-879).
 * Add a dismissible admin notice on `manage_woocommerce` screens that summarizes quarantined orphan webhooks and links to the FastSpring log for manual replay (VAL-879).
+
+= 2.6.1 =
+* Strip the `id` attribute WordPress 6.3+ auto-injects on the FastSpring Builder script tag so our `id="fsc-api"` replacement isn't a duplicate. Browsers keep only the first `id`, which was breaking `document.getElementById('fsc-api')` inside FS Builder and preventing the checkout popup from opening (VAL-882).
+* Clear `_fs_checkout_started_at` when a temp order converts to a real order so the VAL-879 cron-exemption marker no longer lingers on finalized orders (VAL-882).

--- a/woocommerce-gateway-fastspring.php
+++ b/woocommerce-gateway-fastspring.php
@@ -4,7 +4,7 @@
  * Description: Plugin Taken over by Built Mighty because plugin is no longer maintained: https://github.com/cyberwombat/woocommerce-fastspring-payment-gateway/blob/master/README.md - Accept credit card, PayPal, Amazon Pay and other payments on your store using FastSpring.
  * Author: Enradia
  * Author URI: https://enradia.com/
- * Version: 2.6.0
+ * Version: 2.6.1
  * Requires at least: 4.4
  * Tested up to: 6.9
  * WC requires at least: 3.0
@@ -21,7 +21,7 @@ if (!defined('ABSPATH')) {
 /**
  * Required minimums and constants
  */
-define('WC_FASTSPRING_VERSION', '2.6.0');
+define('WC_FASTSPRING_VERSION', '2.6.1');
 define('WC_FASTSPRING_SCRIPT', 'https://d1f8f9xcsvx3ha.cloudfront.net/sbl/0.8.3/fastspring-builder.min.js');
 define('WC_FASTSPRING_MIN_PHP_VER', '5.6.0');
 define('WC_FASTSPRING_MIN_WC_VER', '3.0.0');
@@ -144,6 +144,11 @@ if (!class_exists('WC_FastSpring')):
       {
           if ('fastspring' === $handle) {
               $debug = defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ? 'true' : 'false';
+              // VAL-882: WP 6.3+ auto-injects id="fastspring-js" during enqueue. Strip
+              // it so our id="fsc-api" injection below isn't a duplicate — the FS
+              // Builder library locates its own script tag via getElementById('fsc-api')
+              // and throws on null when the browser parses only the first (WP-added) id.
+              $tag = preg_replace( '/\s+id="[^"]*"/', '', $tag, 1 );
               return str_replace(' src', ' id="fsc-api" data-storefront="' . $this->get_storefront_path() . '" data-before-requests-callback="fastspringBeforeRequestHandler" data-access-key="' . self::get_setting('access_key') . '" '. ($debug ? 'data-debug="true" data-test="' . (self::get_setting('testmode') ? 'yes' : 'no') . '" data-version="' . WC_FASTSPRING_VERSION .'" data-data-callback="dataCallbackFunction" data-error-callback="errorCallback"' : '') . ' data-popup-closed="fastspringPopupCloseHandler" src', $tag);
           }
           return $tag;


### PR DESCRIPTION
Merges `rc/2.6.1` into `master` for the 2.6.1 patch release.

Includes:
- **VAL-882** — Strip WP-auto `id` attribute on the FS Builder script tag so the checkout popup module loads, and clear the `_fs_checkout_started_at` marker once temp orders convert.
- Version bump 2.6.0 → 2.6.1